### PR TITLE
circular import v3.9.4

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,16 +1,9 @@
-from terra_sdk.client.lcd import LCDClient
-from terra_sdk.key.mnemonic import MnemonicKey
-
 import constants
 
 from bots.rebalance import create_then_redeem
 import config
 
-mk = MnemonicKey(config.mnemonic)
 
-terra = LCDClient(chain_id=constants.network_info[config.net]['moniker'],
-                  url=constants.network_info[config.net]['url'])
-wallet = terra.wallet(mk)
 cluster_address = constants.cluster_contracts[config.net][config.cluster]
 
 create_then_redeem(config.total_capital, cluster_address, config.imbalance_threshold)

--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,8 @@
 import constants
+import config
 
 from bots.rebalance import create_then_redeem
-import config
+
 
 
 cluster_address = constants.cluster_contracts[config.net][config.cluster]

--- a/bots/rebalance.py
+++ b/bots/rebalance.py
@@ -2,7 +2,6 @@ import time
 
 import numpy as np
 
-from bot import terra, wallet
 from helpers.helpers import get_info_from_state, split_imbalances, get_sorted_assets, get_ust_pairs_for_assets, \
     swap_ust_for_assets, sell_assets_from_redeem
 from helpers.math import calculate_notional_imbalance, calculate_separate_imbalances

--- a/config.py
+++ b/config.py
@@ -1,5 +1,10 @@
 import os
 
+import constants
+
+from terra_sdk.client.lcd import LCDClient
+from terra_sdk.key.mnemonic import MnemonicKey
+
 net = 'testnet'
 cluster = 'lunaust'
 # mnemonic = "MNEMONIC"
@@ -9,4 +14,10 @@ imbalance_threshold = 2000000
 
 home = os.environ['HOME']
 mnemonic = open(home + "/mk.txt").readline()
+
+mk = MnemonicKey(mnemonic)
+
+terra = LCDClient(chain_id=constants.network_info[net]['moniker'],
+                  url=constants.network_info[net]['url'])
+wallet = terra.wallet(mk)
 

--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -1,8 +1,8 @@
 import time
+import config
 
 import numpy as np
 
-from bot import terra, wallet
 from market.astroport import factory as astro_factory, pair as pair
 from nebula import cluster as cluster
 from objects.asset import Asset
@@ -25,16 +25,16 @@ def get_info_from_state(client, cluster_address):
     return i, w, p, outstanding_balance_tokens, underlying_assets
 
 
-def get_ust_pairs_for_assets(assets: [Asset]):
+def get_ust_pairs_for_assets(assets: list([Asset])):
     pairs = []
     for i in range(len(assets)):
         if assets[i] == "uusd":
             pairs.append(None)
         elif assets[i].startswith("u"):
-            pairs.append(astro_factory.query_pair(terra, Asset(denom="uusd"), Asset(denom=assets[i]))['contract_addr'])
+            pairs.append(astro_factory.query_pair(config.terra, Asset(denom="uusd"), Asset(denom=assets[i]))['contract_addr'])
         else:
             pairs.append(
-                astro_factory.query_pair(terra, Asset(denom="uusd"), Asset(contract_addr=assets[i]))['contract_addr'])
+                astro_factory.query_pair(config.terra, Asset(denom="uusd"), Asset(contract_addr=assets[i]))['contract_addr'])
     return pairs
 
 
@@ -67,12 +67,12 @@ def swap_ust_for_assets(pairs, asset_spend, sorted_assets):
     acquired_assets = []
     for i in range(len(pairs)):
         if pairs[i]:
-            res = pair.execute_swap(terra, wallet, pairs[i], Asset(denom="uusd", amount=asset_spend[i]),
+            res = pair.execute_swap(config.terra, config.wallet, pairs[i], Asset(denom="uusd", amount=asset_spend[i]),
                                     0.005)
             time.sleep(7)
             acquired_assets.append(Asset(contract_addr=sorted_assets[i],
                                       amount=res.logs[0].events_by_type['from_contract']['return_amount'][0]) if
-                                sorted_assets[i].startswith("terra1") else Asset(denom=sorted_assets[i], amount=
+                                sorted_assets[i].startswith("config.terra1") else Asset(denom=sorted_assets[i], amount=
             res.logs[0].events_by_type['from_contract']['return_amount'][0]))
         else:
             acquired_assets.append(Asset(denom="uusd", amount=asset_spend[i]))
@@ -114,8 +114,8 @@ def sell_assets_from_redeem(redeem_res):
         if token.denom == "uusd":
             totals += token.amount
         else:
-            q = astro_factory.query_pair(terra, Asset(denom="uusd"), token)
-            redeem_res = pair.execute_swap(terra, wallet, q['contract_addr'], token, 0.005)
+            q = astro_factory.query_pair(config.terra, Asset(denom="uusd"), token)
+            redeem_res = pair.execute_swap(config.terra, config.wallet, q['contract_addr'], token, 0.005)
             time.sleep(6)
             totals += int(redeem_res.logs[len(redeem_res.logs) - 1].events_by_type['coin_received']['amount'][0][
                           :redeem_res.logs[len(redeem_res.logs) - 1].events_by_type['coin_received']['amount'][0].find(


### PR DESCRIPTION
was getting circular import error when running bot.py

moved terra, wallet info to config and replaced terra/wallet variables with config.terra/wallet.

not sure if this is right way to do it but bot.py works now

